### PR TITLE
fixing modal flash issue, create note data now getting captured

### DIFF
--- a/app/javascript/components/CreateModal.tsx
+++ b/app/javascript/components/CreateModal.tsx
@@ -1,0 +1,100 @@
+import React, {useState} from "react";
+import {Button, Modal, ModalBody, ModalFooter, ModalHeader} from "reactstrap";
+import {SubmitHandler, useFieldArray, useForm} from "react-hook-form";
+import {NoteRQ} from "../lib/types/NoteRQ";
+
+const CreateModal = () => {
+    const [modal, setModal] = useState(false);
+    const {register, handleSubmit, formState: {errors}, control} = useForm<NoteRQ>({
+        defaultValues: {title: "", content: "", tags: [{name: "enter tag"}]}
+    });
+    const {fields, append, remove} = useFieldArray({
+        control, name: "tags", rules: {maxLength: 5, minLength: 1}
+    })
+
+    const onSubmit: SubmitHandler<NoteRQ> = data => {
+        try {
+            console.log(data);
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    const toggle = () => setModal(!modal);
+    const closeBtn = (
+        <button className="btn-close" onClick={toggle} type="button">
+        </button>
+    );
+
+    return <div>
+        <Modal isOpen={modal} className="modal-dialog modal-dialog-centered">
+            <ModalHeader close={closeBtn}>
+                Note Information
+            </ModalHeader>
+            <form onSubmit={handleSubmit(onSubmit)} noValidate={true}>
+                <ModalBody>
+                    <div className="mb-3">
+                        <label htmlFor="title" className="form-label">Title</label>
+                        <input className="form-control" id="title" aria-describedby={"titleHelp"}
+                               {...register("title", {
+                                   required: {value: true, message: "Title is required"},
+                                   maxLength: {value: 20, message: "Maximum accepted length is 20"}
+                               })}/>
+                        <div id="titleHelp" className="form-text">Title has a character limitation of 20</div>
+                        {errors.title &&
+                            <div className="invalid-feedback" style={{display: "block"}}>{errors.title?.message}</div>}
+                    </div>
+                    <div className="mb-3">
+                        <label htmlFor="content" className="form-label">Content</label>
+                        <textarea className="form-control" id="content" rows={5} {...register("content", {
+                            required: {value: true, message: "Content is required"},
+                        })}/>
+                        {errors.content &&
+                            <div className="invalid-feedback"
+                                 style={{display: "block"}}>{errors.content?.message}</div>}
+                    </div>
+                    <div className="mb-3">
+                        <label htmlFor="tags" className="form-label">Tags</label>
+                        {fields.map((field, index) => {
+                            return <div key={field.id} className={"row g-3 mb-1"}>
+                                <div className={"col-md-6"}>
+                                    <input className={"form-control"}
+                                           {...register(`tags.${index}.name`, {
+                                               maxLength: {
+                                                   value: 10,
+                                                   message: "Maximum accepted length is 10"
+                                               }
+                                           })}/>
+                                </div>
+                                <div className={"col-md-6"}>
+                                    <div className={"d-grid gap-2 d-md-flex justify-content"}>
+                                        <button type={"button"} className={"btn btn-primary"}
+                                                onClick={() => append([{
+                                                    name: "enter tag",
+                                                }])}>+
+                                        </button>
+                                        <button type={"button"} className={"btn btn-danger"}
+                                                onClick={() => remove(index)}>-
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        })}
+                        <div id="tagsHelp" className="form-text">Click +/- to add/remove more relevant tags</div>
+                        {errors.tags &&
+                            <div className="invalid-feedback"
+                                 style={{display: "block"}}>{errors.tags?.message}</div>}
+                    </div>
+                </ModalBody>
+                <ModalFooter>
+                    <button type="submit" className="btn btn-success">Create</button>
+                    {' '}
+                    <button className="btn btn-danger" onClick={toggle}>Cancel</button>
+                </ModalFooter>
+            </form>
+        </Modal>
+        <Button color="primary" className="mb-4 float-end" onClick={toggle}>
+            Create Note
+        </Button>
+    </div>;
+}
+export default CreateModal;

--- a/app/javascript/components/Note.tsx
+++ b/app/javascript/components/Note.tsx
@@ -1,40 +1,14 @@
 import React, {useEffect, useState} from "react";
 import {NoteRS} from "../lib/types/NoteRS";
 import axios from "axios";
-import {
-    Button, CardColumns,
-    Form,
-    FormFeedback,
-    FormGroup,
-    Input,
-    Label,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader, Row
-} from "reactstrap";
-import {SubmitHandler, useForm} from "react-hook-form";
-import {NoteRQ} from "../lib/types/NoteRQ";
+import {CardColumns, Row} from "reactstrap";
 import {Tag} from "../lib/types/Tag";
 import {Link} from "react-router-dom";
+import CreateModal from "./CreateModal";
 
 export default function Note() {
     const [notes, setNotes] = useState<NoteRS[]>([]);
-    const [modal, setModal] = useState(false);
-    const {register, handleSubmit, formState: {errors}} = useForm<NoteRQ>({
-        defaultValues: {title: "", content: ""}
-    });
     const [hover, setHover] = useState(false);
-
-    const onSubmit: SubmitHandler<NoteRQ> = data => {
-        try {
-            console.log(data);
-        } catch (error) {
-            console.error(error);
-        }
-    }
-
-    const toggle = () => setModal(!modal);
 
     useEffect(() => {
         console.log("Note component mounted");
@@ -80,53 +54,9 @@ export default function Note() {
         </div>
     );
 
-    const closeBtn = (
-        <button className="btn-close" onClick={toggle} type="button">
-        </button>
-    );
-
-    const CreateNote = () => <Modal isOpen={modal} className="modal-dialog modal-dialog-centered">
-        <ModalHeader close={closeBtn}>
-            Note Information
-        </ModalHeader>
-        <form onSubmit={handleSubmit(onSubmit)} noValidate={true}>
-            <ModalBody>
-                <div className="mb-3">
-                    <label htmlFor="title" className="form-label">Title</label>
-                    <input className="form-control" id="title" aria-describedby={"titleHelp"}
-                           {...register("title", {
-                               required: {value: true, message: "Title is required"},
-                               maxLength: {value: 20, message: "Maximum accepted length is 20"}
-                           })}/>
-                    <div id="titleHelp" className="form-text">Title has a character limitation of 20</div>
-                    {errors.title &&
-                        <div className="invalid-feedback" style={{display: "block"}}>{errors.title?.message}</div>}
-                </div>
-                <div className="mb-3">
-                    <label htmlFor="content" className="form-label">Content</label>
-                    <textarea className="form-control" id="content" rows={5} {...register("content", {
-                        required: {value: true, message: "Content is required"},
-                    })}/>
-                    {errors.content &&
-                        <div className="invalid-feedback"
-                             style={{display: "block"}}>{errors.content?.message}</div>}
-                </div>
-
-            </ModalBody>
-            <ModalFooter>
-                <button type="submit" className="btn btn-success">Create</button>
-                {' '}
-                <button className="btn btn-danger" onClick={toggle}>Cancel</button>
-            </ModalFooter>
-        </form>
-    </Modal>
-
     return (
         <div className="container m-4">
-            <CreateNote/>
-            <Button color="primary" className="mb-4 float-end" onClick={toggle}>
-                Create Note
-            </Button>
+            <CreateModal/>
             <Row>
                 {notes.map(note =>
                     <CardColumns className={"m-2"} key={note.id}>

--- a/app/javascript/lib/types/NoteRQ.ts
+++ b/app/javascript/lib/types/NoteRQ.ts
@@ -1,4 +1,7 @@
+import {Tag} from "./Tag";
+
 export interface NoteRQ {
     title: string;
     content: string;
+    tags: Tag[]
 }

--- a/app/javascript/lib/types/Tag.ts
+++ b/app/javascript/lib/types/Tag.ts
@@ -1,6 +1,6 @@
 export interface Tag {
-    id: number;
+    id?: number;
     name: string;
-    created_at: string;
-    updated_at: string;
+    created_at?: string;
+    updated_at?: string;
 }


### PR DESCRIPTION
The modal flash issue was occurring because of the `modal` state getting refreshed whenever any operation on the modal was happening. Due to this, the entire render of the modal was re-happening. To resolve, the modal is separated as a child component with its component (since the child state will not be shared with the parent state in the React State Hierarchy) hence the unnecessary state re-render is avoided.  You can refer to the new component [here](https://github.com/suvadeepghoshal/note-app/blob/d623d371f8051f84a451bc204083032ddd53cacb/app/javascript/components/Note.tsx#L59) 

The new [component](https://github.com/suvadeepghoshal/note-app/blob/bugfix/create-modal-not-working/app/javascript/components/CreateModal.tsx) now supports validation and form submission. **The API call to back-end is not in the scope of the PR** The modal component also makes use of the `useFieldArray` hook from React Hook Form's [useFieldArray](https://react-hook-form.com/docs/usefieldarray) for which you can refer the implementation [here](https://github.com/suvadeepghoshal/note-app/blob/d623d371f8051f84a451bc204083032ddd53cacb/app/javascript/components/CreateModal.tsx#L57).

Although _one drawback_ (which will be corrected in the front-end branch, as it is not in the scope of this bug) the [validators](https://github.com/suvadeepghoshal/note-app/blob/d623d371f8051f84a451bc204083032ddd53cacb/app/javascript/components/CreateModal.tsx#L12) of the `useFieldArray` for minimum and maximum number of supported tags are still not working

**Reference of the `createNote` modal**
![image](https://github.com/suvadeepghoshal/note-app/assets/62047996/4ad46c7a-abca-4bb3-8abe-c64be44302b8)
